### PR TITLE
뒤집어서 화면 어둡게 하기 기능 구현

### DIFF
--- a/Project_Timer/Global/UserDefaultsManager.swift
+++ b/Project_Timer/Global/UserDefaultsManager.swift
@@ -18,6 +18,7 @@ struct UserDefaultsManager {
         case restPushable = "restPushable"
         case updatePushable = "updatePushable"
         case timelabelsAnimation = "timelabelsAnimation"
+        case dimWhenFaceDown = "dimWhenFaceDown"
         case keepTheScreenOn = "keepTheScreenOn"
     }
     

--- a/Project_Timer/Setting/Main/SettingVM.swift
+++ b/Project_Timer/Setting/Main/SettingVM.swift
@@ -40,6 +40,7 @@ final class SettingVM {
         // UI 설정
         var cells2: [SettingCellInfo] = []
         cells2.append(SettingCellInfo(title: "Times Display".localized(), subTitle: "Smoothly display time changes".localized(), toggleKey: .timelabelsAnimation))
+        cells2.append(SettingCellInfo(title: "Dim When Face Down".localized(), subTitle: "The screen will be dimmed when the screen facing downwards".localized(), toggleKey: .dimWhenFaceDown))
         cells2.append(SettingCellInfo(title: "Keep The Screen On".localized(), subTitle: "The screen does not turn off while the timer is running.".localized(), toggleKey: .keepTheScreenOn))
         // 버전 및 업데이트 내역
         var cells3: [SettingCellInfo] = []

--- a/Project_Timer/Setting/Main/SettingVM.swift
+++ b/Project_Timer/Setting/Main/SettingVM.swift
@@ -40,8 +40,8 @@ final class SettingVM {
         // UI 설정
         var cells2: [SettingCellInfo] = []
         cells2.append(SettingCellInfo(title: "Times Display".localized(), subTitle: "Smoothly display time changes".localized(), toggleKey: .timelabelsAnimation))
-        cells2.append(SettingCellInfo(title: "Dim When Face Down".localized(), subTitle: "The screen will be dimmed when the screen facing downwards".localized(), toggleKey: .dimWhenFaceDown))
-        cells2.append(SettingCellInfo(title: "Keep The Screen On".localized(), subTitle: "The screen does not turn off while the timer is running.".localized(), toggleKey: .keepTheScreenOn))
+        cells2.append(SettingCellInfo(title: "Flip to start recording".localized(), subTitle: "Record will be start automatically when flip the device".localized(), toggleKey: .dimWhenFaceDown))
+        cells2.append(SettingCellInfo(title: "Keep screen on".localized(), subTitle: "Keep the screen on during recording".localized(), toggleKey: .keepTheScreenOn))
         // 버전 및 업데이트 내역
         var cells3: [SettingCellInfo] = []
         let versionCell = SettingCellInfo(title: "Version Info".localized(), subTitle: "Latest version".localized()+":", rightTitle: String.currentVersion, link: NetworkURL.appstore)

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -254,10 +254,12 @@ extension StopwatchViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
+                    UIDevice.current.isProximityMonitoringEnabled = true
                     self?.disableIdleTimer()
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
+                    UIDevice.current.isProximityMonitoringEnabled = false
                     self?.enableIdleTimer()
                 }
             })

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -435,10 +435,10 @@ extension StopwatchViewController {
     }
     
     @objc private func didProximityStateChange() {
-        guard let running = viewModel?.timerRunning else { return }
+        guard let isTimerRunning = viewModel?.timerRunning else { return }
         
         if UIDevice.current.proximityState {
-            if !running { self.startOrStopTimer() }
+            if isTimerRunning == false { self.startOrStopTimer() }
             self.enterBackground()
         } else {
             self.enterForeground()

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -254,13 +254,13 @@ extension StopwatchViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
-                    UIDevice.current.isProximityMonitoringEnabled = true
                     self?.disableIdleTimer()
+                    self?.enableProximityMonitoring()
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
-                    UIDevice.current.isProximityMonitoringEnabled = false
                     self?.enableIdleTimer()
+                    self?.disableProximityMonitoring()
                 }
             })
             .store(in: &self.cancellables)
@@ -407,6 +407,17 @@ extension StopwatchViewController {
             self.warningRecordDate.alpha = 0
             self.todayLabel.textColor = .white
         }
+    }
+    
+    private func enableProximityMonitoring() {
+        let dimWhenFaceDown = UserDefaultsManager.get(forKey: .dimWhenFaceDown) as? Bool ?? true
+        if dimWhenFaceDown {
+            UIDevice.current.isProximityMonitoringEnabled = true
+        }
+    }
+    
+    private func disableProximityMonitoring() {
+        UIDevice.current.isProximityMonitoringEnabled = false
     }
     
     private func disableIdleTimer() {

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -142,7 +142,7 @@ extension StopwatchViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(pauseWhenBackground(noti:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(noti:)), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceRotated), name: UIDevice.orientationDidChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didProximityValueChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didProximityStateChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(forName: .removeNewRecordWarning, object: nil, queue: .main) { [weak self] _ in
             self?.hideWarningRecordDate()
         }
@@ -421,7 +421,7 @@ extension StopwatchViewController {
         UIDevice.current.isProximityMonitoringEnabled = false
     }
     
-    @objc private func didProximityValueChange() {
+    @objc private func didProximityStateChange() {
         if UIDevice.current.proximityState {
             self.enterBackground()
         } else {

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -142,6 +142,7 @@ extension StopwatchViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(pauseWhenBackground(noti:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(noti:)), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceRotated), name: UIDevice.orientationDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didProximityValueChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(forName: .removeNewRecordWarning, object: nil, queue: .main) { [weak self] _ in
             self?.hideWarningRecordDate()
         }
@@ -420,6 +421,14 @@ extension StopwatchViewController {
         UIDevice.current.isProximityMonitoringEnabled = false
     }
     
+    @objc private func didProximityValueChange() {
+        if UIDevice.current.proximityState {
+            self.enterBackground()
+        } else {
+            self.enterForeground()
+        }
+    }
+    
     private func disableIdleTimer() {
         let keepTheScreenOn = UserDefaultsManager.get(forKey: .keepTheScreenOn) as? Bool ?? true
         if keepTheScreenOn {
@@ -466,16 +475,24 @@ extension StopwatchViewController {
 
 // MARK: Background
 extension StopwatchViewController {
-    @objc func pauseWhenBackground(noti: Notification) {
+    private func enterBackground() {
         guard let running = self.viewModel?.runningUI,
               running == true else { return }
         self.viewModel?.enterBackground()
     }
     
-    @objc func willEnterForeground(noti: Notification) {
+    private func enterForeground() {
         guard let running = self.viewModel?.runningUI,
               running == true else { return }
         self.viewModel?.enterForground()
+    }
+    
+    @objc func pauseWhenBackground(noti: Notification) {
+        self.enterBackground()
+    }
+    
+    @objc func willEnterForeground(noti: Notification) {
+        self.enterForeground()
     }
 }
 

--- a/Project_Timer/Stopwatch/ViewModel/StopwatchVM.swift
+++ b/Project_Timer/Stopwatch/ViewModel/StopwatchVM.swift
@@ -14,13 +14,13 @@ final class StopwatchVM {
     @Published private(set) var times: Times
     @Published private(set) var daily: Daily
     @Published private(set) var task: String
-    @Published private(set) var runningUI = false
-    @Published private(set) var warningNewDate = false
-    private(set) var timerRunning = false {
+    @Published private(set) var runningUI = false {
         didSet {
-            self.timeOfStopwatchViewModel.isRunning = timerRunning
+            self.timeOfStopwatchViewModel.isRunning = runningUI
         }
     }
+    @Published private(set) var warningNewDate = false
+    private(set) var timerRunning = false
     private var timerCount: Int = 0
     private let userNotificationCenter = UNUserNotificationCenter.current()
     private var showAnimation: Bool = true

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -239,13 +239,13 @@ extension TimerViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
+                    self?.enableProximityMonitoring()
                     self?.disableIdleTimer()
-                    UIDevice.current.isProximityMonitoringEnabled = true
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
                     self?.enableIdleTimer()
-                    UIDevice.current.isProximityMonitoringEnabled = false
+                    self?.disableProximityMonitoring()
                 }
             })
             .store(in: &self.cancellables)
@@ -418,6 +418,17 @@ extension TimerViewController {
             self.warningRecordDate.alpha = 0
             self.todayLabel.textColor = .white
         }
+    }
+    
+    private func enableProximityMonitoring() {
+        let dimWhenFaceDown = UserDefaultsManager.get(forKey: .dimWhenFaceDown) as? Bool ?? true
+        if dimWhenFaceDown {
+            UIDevice.current.isProximityMonitoringEnabled = true
+        }
+    }
+    
+    private func disableProximityMonitoring() {
+        UIDevice.current.isProximityMonitoringEnabled = false
     }
     
     private func disableIdleTimer() {

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -133,7 +133,7 @@ extension TimerViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(pauseWhenBackground(noti:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(noti:)), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceRotated), name: UIDevice.orientationDidChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didProximityValueChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didProximityStateChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(forName: .removeNewRecordWarning, object: nil, queue: .main) { [weak self] _ in
             self?.hideWarningRecordDate()
         }
@@ -432,7 +432,7 @@ extension TimerViewController {
         UIDevice.current.isProximityMonitoringEnabled = false
     }
     
-    @objc private func didProximityValueChange() {
+    @objc private func didProximityStateChange() {
         if UIDevice.current.proximityState {
             self.enterBackground()
         } else {

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -240,10 +240,12 @@ extension TimerViewController {
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
                     self?.disableIdleTimer()
+                    UIDevice.current.isProximityMonitoringEnabled = true
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
                     self?.enableIdleTimer()
+                    UIDevice.current.isProximityMonitoringEnabled = false
                 }
             })
             .store(in: &self.cancellables)

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -133,6 +133,7 @@ extension TimerViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(pauseWhenBackground(noti:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(noti:)), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceRotated), name: UIDevice.orientationDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didProximityValueChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(forName: .removeNewRecordWarning, object: nil, queue: .main) { [weak self] _ in
             self?.hideWarningRecordDate()
         }
@@ -431,6 +432,14 @@ extension TimerViewController {
         UIDevice.current.isProximityMonitoringEnabled = false
     }
     
+    @objc private func didProximityValueChange() {
+        if UIDevice.current.proximityState {
+            self.enterBackground()
+        } else {
+            self.enterForeground()
+        }
+    }
+    
     private func disableIdleTimer() {
         let keepTheScreenOn = UserDefaultsManager.get(forKey: .keepTheScreenOn) as? Bool ?? true
         if keepTheScreenOn {
@@ -477,16 +486,24 @@ extension TimerViewController {
 
 // MARK: Background
 extension TimerViewController {
-    @objc func pauseWhenBackground(noti: Notification) {
+    private func enterBackground() {
         guard let running = self.viewModel?.runningUI,
               running == true else { return }
         self.viewModel?.enterBackground()
     }
     
-    @objc func willEnterForeground(noti: Notification) {
+    private func enterForeground() {
         guard let running = self.viewModel?.runningUI,
               running == true else { return }
         self.viewModel?.enterForground()
+    }
+    
+    @objc func pauseWhenBackground(noti: Notification) {
+        self.enterBackground()
+    }
+    
+    @objc func willEnterForeground(noti: Notification) {
+        self.enterForeground()
     }
 }
 

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -446,10 +446,10 @@ extension TimerViewController {
     }
     
     @objc private func didProximityStateChange() {
-        guard let running = viewModel?.timerRunning else { return }
+        guard let isTimerRunning = viewModel?.timerRunning else { return }
         
         if UIDevice.current.proximityState {
-            if !running { self.startOrStopTimer() }
+            if isTimerRunning == false { self.startOrStopTimer() }
             self.enterBackground()
         } else {
             self.enterForeground()

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -71,6 +71,16 @@ class TimerViewController: UIViewController {
         self.viewModel?.updateDaily()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.enableProximityMonitoring()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        self.disableProximityMonitoring()
+    }
+    
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         self.updateTabbarColor()
@@ -81,11 +91,7 @@ class TimerViewController: UIViewController {
     }
     
     @IBAction func timerStartStopAction(_ sender: Any) {
-        guard self.viewModel?.task ?? "none" != "none" else {
-            self.showTaskWarningAlert()
-            return
-        }
-        self.viewModel?.timerAction()
+        self.startOrStopTimer()
     }
     
     @IBAction func setting(_ sender: Any) {
@@ -133,7 +139,6 @@ extension TimerViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(pauseWhenBackground(noti:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(noti:)), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceRotated), name: UIDevice.orientationDidChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didProximityStateChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(forName: .removeNewRecordWarning, object: nil, queue: .main) { [weak self] _ in
             self?.hideWarningRecordDate()
         }
@@ -193,6 +198,14 @@ extension TimerViewController {
         setTimerVC.delegate = self
         present(setTimerVC, animated: true, completion: nil)
     }
+    
+    private func startOrStopTimer() {
+        guard self.viewModel?.task ?? "none" != "none" else {
+            self.showTaskWarningAlert()
+            return
+        }
+        self.viewModel?.timerAction()
+    }
 }
 
 // MARK: - binding
@@ -240,13 +253,11 @@ extension TimerViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
-                    self?.enableProximityMonitoring()
                     self?.disableIdleTimer()
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
                     self?.enableIdleTimer()
-                    self?.disableProximityMonitoring()
                 }
             })
             .store(in: &self.cancellables)
@@ -422,6 +433,7 @@ extension TimerViewController {
     }
     
     private func enableProximityMonitoring() {
+        NotificationCenter.default.addObserver(self, selector: #selector(didProximityStateChange), name: UIDevice.proximityStateDidChangeNotification, object: nil)
         let dimWhenFaceDown = UserDefaultsManager.get(forKey: .dimWhenFaceDown) as? Bool ?? true
         if dimWhenFaceDown {
             UIDevice.current.isProximityMonitoringEnabled = true
@@ -430,10 +442,14 @@ extension TimerViewController {
     
     private func disableProximityMonitoring() {
         UIDevice.current.isProximityMonitoringEnabled = false
+        NotificationCenter.default.removeObserver(self, name: UIDevice.proximityStateDidChangeNotification, object: nil)
     }
     
     @objc private func didProximityStateChange() {
+        guard let running = viewModel?.timerRunning else { return }
+        
         if UIDevice.current.proximityState {
+            if !running { self.startOrStopTimer() }
             self.enterBackground()
         } else {
             self.enterForeground()

--- a/Project_Timer/Timer/ViewModel/TimerVM.swift
+++ b/Project_Timer/Timer/ViewModel/TimerVM.swift
@@ -14,14 +14,14 @@ final class TimerVM {
     @Published private(set) var times: Times
     @Published private(set) var daily: Daily
     @Published private(set) var task: String
-    @Published private(set) var runningUI = false
-    @Published private(set) var soundAlert = false
-    @Published private(set) var warningNewDate = false
-    private(set) var timerRunning = false {
+    @Published private(set) var runningUI = false {
         didSet {
-            self.timeOfTimerViewModel.isRunning = timerRunning
+            self.timeOfTimerViewModel.isRunning = runningUI
         }
     }
+    @Published private(set) var soundAlert = false
+    @Published private(set) var warningNewDate = false
+    private(set) var timerRunning = false
     private var timerCount: Int = 0
     private let userNotificationCenter = UNUserNotificationCenter.current()
     private var showAnimation: Bool = true

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -151,6 +151,10 @@
 
 "Smoothly display time changes" = "Smoothly display time changes";
 
+"Dim When Face Down" = "Dim When Face Down";
+
+"The screen will be dimmed when the screen facing downwards" = "The screen will be dimmed when the screen facing downwards";
+
 "Keep The Screen On" = "Keep The Screen On";
 
 "The screen does not turn off while the timer is running." = "The screen does not turn off while the timer is running.";

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -151,10 +151,10 @@
 
 "Smoothly display time changes" = "Smoothly display time changes";
 
-"Dim When Face Down" = "Dim When Face Down";
+"Flip to start recording" = "Flip to start recording";
 
-"The screen will be dimmed when the screen facing downwards" = "The screen will be dimmed when the screen facing downwards";
+"Record will be start automatically when flip the device" = "Record will be start automatically when flip the device";
 
-"Keep The Screen On" = "Keep The Screen On";
+"Keep screen on" = "Keep screen on";
 
-"The screen does not turn off while the timer is running." = "The screen does not turn off while the timer is running.";
+"Keep the screen on during recording" = "Keep the screen on during recording";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -153,6 +153,10 @@ NSPhotoLibraryAddUsageDescription = "사진앨범에 저장되도록 허용버�
 
 "Smoothly display time changes" = "시간변화를 부드럽게 표시합니다";
 
+"Dim When Face Down" = "뒤집어서 어둡게 하기";
+
+"The screen will be dimmed when the screen facing downwards" = "기기를 뒤집어 놓았을 때는 화면이 어두워집니다.";
+
 "Keep The Screen On" = "화면 자동 꺼짐 방지";
 
 "The screen does not turn off while the timer is running." = "타이머 실행 중에는 화면이 항상 켜진 상태로 유지됩니다";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -153,10 +153,10 @@ NSPhotoLibraryAddUsageDescription = "사진앨범에 저장되도록 허용버�
 
 "Smoothly display time changes" = "시간변화를 부드럽게 표시합니다";
 
-"Dim When Face Down" = "뒤집어서 어둡게 하기";
+"Flip to start recording" = "뒤집어서 기록 시작";
 
-"The screen will be dimmed when the screen facing downwards" = "기기를 뒤집어 놓았을 때는 화면이 어두워집니다.";
+"Record will be started automatically when flip the device" = "기기를 뒤집으면 자동으로 기록이 시작됩니다";
 
-"Keep The Screen On" = "화면 자동 꺼짐 방지";
+"Keep screen on" = "항상 화면 켜짐 유지";
 
-"The screen does not turn off while the timer is running." = "타이머 실행 중에는 화면이 항상 켜진 상태로 유지됩니다";
+"Keep the screen on during recording" = "기록중에는 화면이 항상 켜진 상태로 유지됩니다";


### PR DESCRIPTION
## 작업 내용
- [x] 기기를 엎어 놓으면 화면이 어두워지는 기능 구현
- [x] 해당 기능 On/Off가 가능하도록 설정창에 토글 옵션 추가

## 동작 화면

| 설정창 |
| -------- |
| <img src="https://user-images.githubusercontent.com/70833900/178425373-4c5cca23-400e-4b62-b7bd-decf65bbaa79.png" width="200"> |

## 고민과 해결 및 리뷰 포인트
- 기기를 엎어 놓았다는 것을 어떻게 감지할 것인가?
  - **조도 센서**
    - 로직
      - 뒤집어 놓으면 조도 센서가 가려지면서 어둡다고 인식할 것이므로 주변이 어두울 때를 엎어 놓은 것으로 감지한다.
    - 문제점
      - 그냥 주변이 어두운 상황(ex. 밤)에도 뒤집었다고 인식하는 문제가 발생할 것이다. 
  - **orientation - face down**
    - 로직
      - 디바이스의 화면이 아래를 향하도록 놓여있을 때를 엎어 놓은 것으로 감지한다. 
    - 장점
      - 실제로 디바이스를 뒤집었을 때를 감지할 수 있다. 
    - 문제점
      - 기기의 화면 방향 고정 설정을 켜두면 orientation 변화를 감지하지 못한다.
      - 검은 화면을 직접 처리해주어야 한다.
  - **근접 센서**
    - 로직
      - 뒤집어 놓으면 근접 센서도 가려지므로 근접 센서가 감지되었을 때를 엎어 놓은 것으로 감지한다.
    - 장점
      - 검은 화면을 직접 처리할 필요가 없다. 근접 센서가 가려지면 저절로 어두운 화면 처리를 해주기 때문. (통화할 때 귀에 가져다대면 화면이 꺼지는 것과 똑같이)
    - 문제점
      - 실제로 기기를 엎어 놓지 않았는데 근접 센서가 가려지기만 해도 화면이 어두워진다. 
      - 근접 센서가 없는 기기는 어떻게 할 것인가?
        - 공식 문서를 보면 모든 iOS 디바이스에 근접 센서가 있는 것이 아니라고 나와있음.
        - 근접 센서가 없는 디바이스의 경우 아예 설정창에서 해당 항목을 안보여주는 로직을 추가하는 방법을 고민해보았음.

## 레퍼런스
[공식 문서 isProximityMonitoringEnabled](https://developer.apple.com/documentation/uikit/uidevice/1620017-isproximitymonitoringenabled)