### PR TITLE
화면 항상 켜기 기능 구현

### DIFF
--- a/Project_Timer/Global/UserDefaultsManager.swift
+++ b/Project_Timer/Global/UserDefaultsManager.swift
@@ -18,6 +18,7 @@ struct UserDefaultsManager {
         case restPushable = "restPushable"
         case updatePushable = "updatePushable"
         case timelabelsAnimation = "timelabelsAnimation"
+        case keepTheScreenOn = "keepTheScreenOn"
     }
     
     static func set<T>(to: T, forKey: Self.Keys) {

--- a/Project_Timer/Setting/Main/SettingVM.swift
+++ b/Project_Timer/Setting/Main/SettingVM.swift
@@ -40,6 +40,7 @@ final class SettingVM {
         // UI 설정
         var cells2: [SettingCellInfo] = []
         cells2.append(SettingCellInfo(title: "Times Display".localized(), subTitle: "Smoothly display time changes".localized(), toggleKey: .timelabelsAnimation))
+        cells2.append(SettingCellInfo(title: "Keep The Screen On".localized(), subTitle: "The screen does not turn off while the timer is running.".localized(), toggleKey: .keepTheScreenOn))
         // 버전 및 업데이트 내역
         var cells3: [SettingCellInfo] = []
         let versionCell = SettingCellInfo(title: "Version Info".localized(), subTitle: "Latest version".localized()+":", rightTitle: String.currentVersion, link: NetworkURL.appstore)

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -254,9 +254,11 @@ extension StopwatchViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
+                    UIApplication.shared.isIdleTimerDisabled = true
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
+                    UIApplication.shared.isIdleTimerDisabled = false
                 }
             })
             .store(in: &self.cancellables)

--- a/Project_Timer/Stopwatch/StopwatchViewController.swift
+++ b/Project_Timer/Stopwatch/StopwatchViewController.swift
@@ -254,11 +254,11 @@ extension StopwatchViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
-                    UIApplication.shared.isIdleTimerDisabled = true
+                    self?.disableIdleTimer()
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
-                    UIApplication.shared.isIdleTimerDisabled = false
+                    self?.enableIdleTimer()
                 }
             })
             .store(in: &self.cancellables)
@@ -405,6 +405,17 @@ extension StopwatchViewController {
             self.warningRecordDate.alpha = 0
             self.todayLabel.textColor = .white
         }
+    }
+    
+    private func disableIdleTimer() {
+        let keepTheScreenOn = UserDefaultsManager.get(forKey: .keepTheScreenOn) as? Bool ?? true
+        if keepTheScreenOn {
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
+    }
+    
+    private func enableIdleTimer() {
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 }
 

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -239,11 +239,11 @@ extension TimerViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
-                    UIApplication.shared.isIdleTimerDisabled = true
+                    self?.disableIdleTimer()
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
-                    UIApplication.shared.isIdleTimerDisabled = false
+                    self?.enableIdleTimer()
                 }
             })
             .store(in: &self.cancellables)
@@ -416,6 +416,17 @@ extension TimerViewController {
             self.warningRecordDate.alpha = 0
             self.todayLabel.textColor = .white
         }
+    }
+    
+    private func disableIdleTimer() {
+        let keepTheScreenOn = UserDefaultsManager.get(forKey: .keepTheScreenOn) as? Bool ?? true
+        if keepTheScreenOn {
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
+    }
+    
+    private func enableIdleTimer() {
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 }
 

--- a/Project_Timer/Timer/TimerViewController.swift
+++ b/Project_Timer/Timer/TimerViewController.swift
@@ -239,9 +239,11 @@ extension TimerViewController {
                     NotificationCenter.default.post(name: .removeNewRecordWarning, object: nil)
                     self?.setStartColor()
                     self?.setButtonsEnabledFalse()
+                    UIApplication.shared.isIdleTimerDisabled = true
                 } else {
                     self?.setStopColor()
                     self?.setButtonsEnabledTrue()
+                    UIApplication.shared.isIdleTimerDisabled = false
                 }
             })
             .store(in: &self.cancellables)

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -150,3 +150,7 @@
 "Times Display" = "Times Display";
 
 "Smoothly display time changes" = "Smoothly display time changes";
+
+"Keep The Screen On" = "Keep The Screen On";
+
+"The screen does not turn off while the timer is running." = "The screen does not turn off while the timer is running.";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -152,3 +152,7 @@ NSPhotoLibraryAddUsageDescription = "사진앨범에 저장되도록 허용버�
 "Times Display" = "시간 표시";
 
 "Smoothly display time changes" = "시간변화를 부드럽게 표시합니다";
+
+"Keep The Screen On" = "화면 자동 꺼짐 방지";
+
+"The screen does not turn off while the timer is running." = "타이머 실행 중에는 화면이 항상 켜진 상태로 유지됩니다";


### PR DESCRIPTION
## 작업 내용
- [x] 타이머/스톱워치 실행 중에는 화면 항상 켜기 기능 구현
- [x] 해당 기능 On/Off 가능하도록 설정창에 토글 옵션 추가

## 동작 화면
| 설정창 |
| -------- |
| <img src="https://user-images.githubusercontent.com/70833900/178431847-e3d41f0e-4b29-4b14-87e5-1e9f60521198.png" width=200> |

## 고민과 해결 및 리뷰 포인트
- 리젝 가능성
  - 공식 문서에서는 **꼭 필요한 경우에만** idle timer를 diable시키고, **더 이상 필요하지 않은 경우 반드시 다시 enable해야 한다**고 나와있음.
  - 공식 문서에서 idle timer를 disable해야 하는 앱으로 "사용자 인터렉션이 최소일 때도 컨텐츠를 계속 표시해야 하는 게임이나 지도 앱"을 제시하고 있는데, TiTi도 이 경우에 해당하므로 괜찮을 것 같기도 함.

## 레퍼런스
[공식 문서 isIdleTimerDisabled](https://developer.apple.com/documentation/uikit/uiapplication/1623070-idletimerdisabled)
