### PR TITLE
[Hotfix] ver 7.1.1

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -961,7 +961,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -969,7 +969,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.1;
+				MARKETING_VERSION = 7.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
 				PRODUCT_NAME = TiTi;
 				SUPPORTS_MACCATALYST = YES;
@@ -985,7 +985,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -993,7 +993,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.1;
+				MARKETING_VERSION = 7.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
 				PRODUCT_NAME = TiTi;
 				SUPPORTS_MACCATALYST = YES;

--- a/Project_Timer/Stopwatch/ViewModel/StopwatchVM.swift
+++ b/Project_Timer/Stopwatch/ViewModel/StopwatchVM.swift
@@ -156,10 +156,10 @@ final class StopwatchVM {
         self.timerCount = 0
         let endAt = Date()
         RecordController.shared.daily.update(at: endAt)
+        self.updateDaily()
         RecordController.shared.recordTimes.recordStop(finishAt: endAt, taskTime: self.daily.tasks[self.task] ?? 0)
         RecordController.shared.dailys.addDaily(self.daily)
         self.updateTimes()
-        self.updateDaily()
     }
     
     func enterBackground() {

--- a/Project_Timer/Timer/ViewModel/TimerVM.swift
+++ b/Project_Timer/Timer/ViewModel/TimerVM.swift
@@ -181,10 +181,10 @@ final class TimerVM {
         self.soundAlert = true
         let endAt = Date()
         RecordController.shared.daily.update(at: endAt)
+        self.updateDaily()
         RecordController.shared.recordTimes.recordStop(finishAt: endAt, taskTime: self.daily.tasks[self.task] ?? 0)
         RecordController.shared.dailys.addDaily(self.daily)
         self.updateTimes()
-        self.updateDaily()
     }
     
     func enterBackground() {


### PR DESCRIPTION
기록이 비정상적으로 저장되는 버그 수정
Bug fixed: records save logic

## 작업 내용
- [x] StopwatchVM, TimerVM 내 기록정지시 저장하는 로직 순서변경으로 인한 기록꼬임 오류 수정

## 고민과 해결 및 리뷰 포인트
- 타이머 내 표시되는 sum time 값과 log, dailys 창에 표시되는 sum time 의 source 가 다른상태
- 따라서 추후 이부분에 대해서도 update 가 필요할 것으로 보임.

## 레퍼런스
없음.
