### PR TITLE
[Hotfix] 아이패드에서 tabBar Title 잘리는 현상 수정

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -1151,7 +1151,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1159,7 +1159,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3;
+				MARKETING_VERSION = 7.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
 				PRODUCT_NAME = TiTi;
 				SUPPORTS_MACCATALYST = YES;
@@ -1175,7 +1175,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1183,7 +1183,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3;
+				MARKETING_VERSION = 7.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
 				PRODUCT_NAME = TiTi;
 				SUPPORTS_MACCATALYST = YES;

--- a/Project_Timer/Global/Extension/UITabBarController+Extension.swift
+++ b/Project_Timer/Global/Extension/UITabBarController+Extension.swift
@@ -11,19 +11,26 @@ import UIKit
 extension UITabBarController {
     func updateTabbarColor(backgroundColor: UIColor?, tintColor: UIColor, normalColor: UIColor) {
         if #available(iOS 15.0, *){
+            let tabBarItemAppearance = UITabBarItemAppearance()
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                tabBarItemAppearance.normal.titleTextAttributes = [.font: UIFont.systemFont(ofSize: 13), .foregroundColor: normalColor]
+                tabBarItemAppearance.selected.titleTextAttributes = [.font: UIFont.systemFont(ofSize: 13), .foregroundColor: tintColor]
+            } else {
+                tabBarItemAppearance.normal.titleTextAttributes = [.foregroundColor: normalColor]
+                tabBarItemAppearance.selected.titleTextAttributes = [.foregroundColor: tintColor]
+            }
+            
+            tabBarItemAppearance.normal.iconColor = normalColor
+            tabBarItemAppearance.selected.iconColor = tintColor
+            
             let appearance = UITabBarAppearance()
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = backgroundColor
             appearance.shadowColor = .clear
             
-            appearance.compactInlineLayoutAppearance.normal.iconColor = normalColor
-            appearance.compactInlineLayoutAppearance.normal.titleTextAttributes = [.foregroundColor : normalColor]
-            
-            appearance.inlineLayoutAppearance.normal.iconColor = normalColor
-            appearance.inlineLayoutAppearance.normal.titleTextAttributes = [.foregroundColor : normalColor]
-            
-            appearance.stackedLayoutAppearance.normal.iconColor = normalColor
-            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [.foregroundColor : normalColor]
+            appearance.compactInlineLayoutAppearance = tabBarItemAppearance
+            appearance.inlineLayoutAppearance = tabBarItemAppearance
+            appearance.stackedLayoutAppearance = tabBarItemAppearance
             
             self.tabBar.standardAppearance = appearance
             self.tabBar.scrollEdgeAppearance = appearance


### PR DESCRIPTION
아이패드에서 탭바 타이틀이 잘려보이는 버그 수정
Bug fixed: the tab bar title looks truncated on the iPad

## 작업 내용
- [x] UITabBarController+Extension: updateTabbarColor 로직 수정

## 동작 화면

| 잘린상태 | 수정 |
| -------- | -------- |
| <img src="https://i.imgur.com/NNtcd0O.png"> | <img src="https://i.imgur.com/6x5s5zC.png"> |

