### PR TITLE
Month Widget 달력 UI 구현

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -1903,7 +1903,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -1930,7 +1930,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -1903,7 +1903,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -1930,7 +1930,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		87D4DE122A0F83A500993C5C /* MonthWidgetTaskData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D4DE102A0F83A500993C5C /* MonthWidgetTaskData.swift */; };
 		87D4DE132A0F95BE00993C5C /* SelectColor.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 87D4DE162A0F95BE00993C5C /* SelectColor.intentdefinition */; };
 		87D4DE142A0F95BE00993C5C /* SelectColor.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 87D4DE162A0F95BE00993C5C /* SelectColor.intentdefinition */; };
+		87D4DE252A1128CE00993C5C /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D4DE242A1128CE00993C5C /* Date+Extension.swift */; };
 		87D5E65028C7460100D53F8D /* MonthSmallVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D5E64F28C7460100D53F8D /* MonthSmallVM.swift */; };
 		87D5E65328C7477100D53F8D /* MonthTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D5E65228C7477100D53F8D /* MonthTime.swift */; };
 		87D7ED152952B3C100121DE6 /* TestUserSignupInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D7ED142952B3C100121DE6 /* TestUserSignupInfo.swift */; };
@@ -456,6 +457,7 @@
 		87D4DE152A0F95BE00993C5C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; name = Base; path = Base.lproj/SelectColor.intentdefinition; sourceTree = "<group>"; };
 		87D4DE182A0F95C800993C5C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SelectColor.strings; sourceTree = "<group>"; };
 		87D4DE1A2A0F95CA00993C5C /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SelectColor.strings; sourceTree = "<group>"; };
+		87D4DE242A1128CE00993C5C /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		87D5E64F28C7460100D53F8D /* MonthSmallVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthSmallVM.swift; sourceTree = "<group>"; };
 		87D5E65228C7477100D53F8D /* MonthTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthTime.swift; sourceTree = "<group>"; };
 		87D7ED142952B3C100121DE6 /* TestUserSignupInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUserSignupInfo.swift; sourceTree = "<group>"; };
@@ -1156,6 +1158,7 @@
 			isa = PBXGroup;
 			children = (
 				87DD96192A09054A00CA0249 /* String+Extension.swift */,
+				87D4DE242A1128CE00993C5C /* Date+Extension.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -1437,6 +1440,7 @@
 				878B30EC2992BB5A00BE7413 /* widgetLiveActivity.swift in Sources */,
 				87168D99299A819F003ED502 /* UserDefaults+Extension.swift in Sources */,
 				870E11762A0E226D00CFA77C /* MonthWidgetData.swift in Sources */,
+				87D4DE252A1128CE00993C5C /* Date+Extension.swift in Sources */,
 				878B30EA2992BB5A00BE7413 /* widgetBundle.swift in Sources */,
 				87617E682A0CE58900E312EA /* MonthWidgetProvider.swift in Sources */,
 			);

--- a/Widget/Data/MonthWidgetCellData.swift
+++ b/Widget/Data/MonthWidgetCellData.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 struct MonthWidgetCellData {
-    let day: Int
-    let now: Int
+    let day: Date
+    let now: Date
     let time: Int
     let color: String
 }

--- a/Widget/Data/MonthWidgetData.swift
+++ b/Widget/Data/MonthWidgetData.swift
@@ -30,11 +30,11 @@ struct MonthWidgetData {
     
     init(color: Color) {
         self.color = color
-        self.now = Calendar.current.date(byAdding: .month, value: 2, to: Date())!
+        self.now = Date()
     }
     
     init(color: Color, now: Date) {
         self.color = color
-        self.now = Calendar.current.date(byAdding: .month, value: 2, to: now)!
+        self.now = now
     }
 }

--- a/Widget/Data/MonthWidgetData.swift
+++ b/Widget/Data/MonthWidgetData.swift
@@ -30,11 +30,11 @@ struct MonthWidgetData {
     
     init(color: Color) {
         self.color = color
-        self.now = Date()
+        self.now = Calendar.current.date(byAdding: .month, value: 2, to: Date())!
     }
     
     init(color: Color, now: Date) {
         self.color = color
-        self.now = now
+        self.now = Calendar.current.date(byAdding: .month, value: 2, to: now)!
     }
 }

--- a/Widget/Global/Date+Extension.swift
+++ b/Widget/Global/Date+Extension.swift
@@ -1,0 +1,69 @@
+//
+//  Date+Extension.swift
+//  widgetExtension
+//
+//  Created by Kang Minsang on 2023/05/14.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+// MARK: properties based https://github.com/simonberner/calendar-widget project
+extension Date {
+    /// 이번달 첫날
+    var startDayOfMonth: Date {
+        return Calendar.current.dateInterval(of: .month, for: self)!.start
+    }
+    
+    /// 다음달 첫날
+    var startDayOfNextMonth: Date {
+        return Calendar.current.dateInterval(of: .month, for: self)!.end
+    }
+    
+    /// 이번달 마지막날
+    var lastDayOfMonth: Date {
+        return Calendar.current.date(byAdding: .day, value: -1, to: startDayOfNextMonth)!
+    }
+
+    /// 이전달 첫날
+    var startDayOfPreviousMonth: Date {
+        let previousMonthDay = Calendar.current.date(byAdding: .month, value: -1, to: self)!
+        return previousMonthDay.startDayOfMonth
+    }
+
+    /// 달의 날짜수
+    var numberOfDaysInMonth: Int {
+        return Calendar.current.component(.day, from: self.lastDayOfMonth)
+    }
+
+    /// 날짜
+    var dayInt: Int {
+        Calendar.current.component(.day, from: self)
+    }
+
+    /// 달
+    var monthInt: Int {
+        Calendar.current.component(.month, from: self)
+    }
+
+    /// 달
+    var monthFullName: String {
+        self.formatted(.dateTime.month(.wide))
+    }
+    
+    /// 날짜 인덱스 (일: 1 ~ 토: 7)
+    var indexFromSundayOne: Int {
+        return Calendar.current.component(.weekday, from: self)
+    }
+    
+    /// 날짜 인덱스 (월: 0 ~ 토: 6)
+    var indexFromMondayZero: Int {
+        return (self.indexFromSundayOne+5)%7
+    }
+    
+    /// 이번달 시작하는 주의 월요일 날짜
+    var startMondayForCalendar: Date {
+        let indexOfStartDay = startDayOfMonth.indexFromMondayZero
+        return Calendar.current.date(byAdding: .day, value: -indexOfStartDay, to: startDayOfMonth)!
+    }
+}

--- a/Widget/Global/Date+Extension.swift
+++ b/Widget/Global/Date+Extension.swift
@@ -30,6 +30,11 @@ extension Date {
         let previousMonthDay = Calendar.current.date(byAdding: .month, value: -1, to: self)!
         return previousMonthDay.startDayOfMonth
     }
+    
+    /// 다음날
+    var nextDay: Date {
+        return Calendar.current.date(byAdding: .day, value: 1, to: self)!
+    }
 
     /// 달의 날짜수
     var numberOfDaysInMonth: Int {

--- a/Widget/Widgets/MonthWidget/MonthWidgetView.swift
+++ b/Widget/Widgets/MonthWidget/MonthWidgetView.swift
@@ -87,8 +87,13 @@ struct MonthWidgetView: View {
     }
     
     var isKorean: Bool {
-        let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
-        return languageCode == "ko"
+        if #available(iOS 16.0, *){
+            let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
+            return languageCode == "ko"
+        } else {
+            let languageCode = Locale.current.languageCode ?? "en"
+            return languageCode == "ko"
+        }
     }
 }
 
@@ -99,15 +104,7 @@ struct MonthWidgetRightView: View {
     
     var body: some View {
         VStack(alignment: .center, spacing: 1) {
-            HStack(spacing: 0) {
-                ForEach(weekDays, id: \.self) { d in
-                    Text(d)
-                        .font(Font.system(size: 10, weight: .regular))
-                        .foregroundColor(Color(UIColor.secondaryLabel))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                }
-                .frame(height: 12)
-            }
+            CalendarHeaderView(isKorean: isKorean)
             Rectangle()
                 .frame(height: 1)
                 .foregroundColor(Color(UIColor.placeholderText))
@@ -167,12 +164,28 @@ struct MonthWidgetRightView: View {
     var randomTime: Int {
         return Int.random(in: 1...6)
     }
+}
+
+struct CalendarHeaderView: View {
+    let isKorean: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(weekDays, id: \.self) { day in
+                Text(day)
+                    .font(Font.system(size: 10, weight: .regular))
+                    .foregroundColor(Color(UIColor.secondaryLabel))
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .frame(height: 12)
+        }
+    }
     
     var weekDays: [String] {
         if isKorean {
-            return ["일", "월", "화", "수", "목", "금", "토"]
+            return ["월", "화", "수", "목", "금", "토", "일"]
         } else {
-            return ["S", "M", "T", "W", "T", "F", "S"]
+            return ["M", "T", "W", "T", "F", "S", "S"]
         }
     }
 }
@@ -192,7 +205,7 @@ struct TaskRowView: View {
                 .padding(.horizontal, 1.0)
                 .background(Color(UIColor(named: data.color)!).opacity(0.5))
                 .cornerRadius(1)
-            Spacer()
+            Spacer(minLength: 2)
             Text("\(data.taskTime)")
                 .font(Font.system(size: 8, weight: .bold))
                 .foregroundColor(Color(UIColor(named: data.color)!))
@@ -251,6 +264,6 @@ struct MonthWidgetDayCell: View {
 struct MonthWidgetView_Previews: PreviewProvider {
     static var previews: some View {
         MonthWidgetView(MonthWidgetData(color: .D2))
-            .previewLayout(.fixed(width: 338, height: 158))
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }


### PR DESCRIPTION
### 개요
- Issue:  #74 
- Tech Spec: [Month 위젯](https://www.notion.so/Month-a69f59a1a1494c24adb35f2d5e59de13?pvs=4)
- Figma: [Month 위젯](https://www.figma.com/file/T8hsaAguFkPytBiNMOOw03/Develop?type=design&node-id=170-636)

---

### 변경사항
- [x] Date+Extension 날짜계산을 위한 필요값들 추가
- [x] MonthWidgetView 실제 캘린더 표시 구현

### Date+Extension
Foundation 라이브러리에서 제공하는 Calendar를 통해 이번달 첫날, 이번달 마지막날, 이번달 날짜수 등을 구할 수 있도록 하였다.
캘린더에 날짜를 표시하고자 할 때 월요일 날짜부터 순차적으로 쌓여야 하므로 이번달 시작하는 주의 월요일 날짜 값과 이번달 마지막날 날짜 값을 통해 날짜리스트를 구할 수 있었다.
```swift
// MARK: properties based https://github.com/simonberner/calendar-widget project
extension Date {
    /// 이번달 첫날
    var startDayOfMonth: Date {
        return Calendar.current.dateInterval(of: .month, for: self)!.start
    }
    
    /// 다음달 첫날
    var startDayOfNextMonth: Date {
        return Calendar.current.dateInterval(of: .month, for: self)!.end
    }
    
    /// 이번달 마지막날
    var lastDayOfMonth: Date {
        return Calendar.current.date(byAdding: .day, value: -1, to: startDayOfNextMonth)!
    }

    /// 이전달 첫날
    var startDayOfPreviousMonth: Date {
        let previousMonthDay = Calendar.current.date(byAdding: .month, value: -1, to: self)!
        return previousMonthDay.startDayOfMonth
    }
    
    /// 다음날
    var nextDay: Date {
        return Calendar.current.date(byAdding: .day, value: 1, to: self)!
    }

    /// 달의 날짜수
    var numberOfDaysInMonth: Int {
        return Calendar.current.component(.day, from: self.lastDayOfMonth)
    }

    /// 날짜
    var dayInt: Int {
        Calendar.current.component(.day, from: self)
    }

    /// 달
    var monthInt: Int {
        Calendar.current.component(.month, from: self)
    }

    /// 달
    var monthFullName: String {
        self.formatted(.dateTime.month(.wide))
    }
    
    /// 날짜 인덱스 (일: 1 ~ 토: 7)
    var indexFromSundayOne: Int {
        return Calendar.current.component(.weekday, from: self)
    }
    
    /// 날짜 인덱스 (월: 0 ~ 토: 6)
    var indexFromMondayZero: Int {
        return (self.indexFromSundayOne+5)%7
    }
    
    /// 이번달 시작하는 주의 월요일 날짜
    var startMondayForCalendar: Date {
        let indexOfStartDay = startDayOfMonth.indexFromMondayZero
        return Calendar.current.date(byAdding: .day, value: -indexOfStartDay, to: startDayOfMonth)!
    }
}
```
```swift
var calanderDates: [Date] {
    var dates: [Date] = []
    var date = now.startMondayForCalendar
    
    while date <= now.lastDayOfMonth {
        dates.append(date)
        date = date.nextDay
    }
    return dates
}
```

### LazyVGrid
SwiftUI에서 UIKit의 UICollectionView와 같이 행, 렬 형태로 채워서 표시하는 용도로 LazyVGrid가 사용된다.
column 값을 7개로 고정하고, 위에서 구한 calanderDates 값들을 그대로 표시를 하면 월요일부터 채워진 달력을 만들 수 있었다.

```swift
struct MonthWidgetCalendarView: View {
    let now: Date
    let color: String
    let isKorean: Bool
    let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
    
    var body: some View {
        VStack(alignment: .center, spacing: 1) {
            MonthWidgetCalendarHeaderView(isKorean: isKorean)
            
            Rectangle()
                .frame(height: 1)
                .foregroundColor(Color(UIColor.placeholderText))
            Spacer()
                .frame(height: 2)
            
            LazyVGrid(columns: columns, spacing: calendarSpacing()) {
                ForEach(calanderDates, id: \.self) { day in
                    if day.monthInt != now.monthInt {
                        Spacer()
                            .frame(maxWidth: .infinity, alignment: .center)
                    } else {
                        MonthWidgetDayCell(data: MonthWidgetCellData(day: day, now: now, time: randomTime, color: color))
                            .frame(maxWidth: .infinity, alignment: .center)
                    }
                }
            }
        }
        .frame(maxWidth: .infinity)
    }
}
```

### 스크린샷
| 5월 | 7월 |
| -------- | -------- |
| <img src="https://github.com/TimerTiTi/TiTi/assets/65349445/bcbb9375-b58e-4351-a2b3-addac1e4893a"> | <img src="https://github.com/TimerTiTi/TiTi/assets/65349445/3e4a1497-336c-4ba2-adce-0a1d0a400523"> |

---

### 레퍼런스

- [https://seanallen.teachable.com/p/widgets](https://seanallen.teachable.com/p/widgets)
- [https://github.com/simonberner/calendar-widget](https://github.com/simonberner/calendar-widget)
- [https://seons-dev.tistory.com/entry/SwiftUI-Grid](https://seons-dev.tistory.com/entry/SwiftUI-Grid)
- [https://stackoverflow.com/questions/63026130/swiftui-configure-lazyvgrid-with-no-spacing](https://stackoverflow.com/questions/63026130/swiftui-configure-lazyvgrid-with-no-spacing)
- [https://stackoverflow.com/questions/6765441/how-to-get-complete-month-name-from-datetime](https://stackoverflow.com/questions/6765441/how-to-get-complete-month-name-from-datetime)
