### PR TITLE
hotfix: Locale.current.language의 잘못된값으로 인한 로컬라이징 문제 해결

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		870055BF28EE958F00F8BCA9 /* SettingRecordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870055BE28EE958F00F8BCA9 /* SettingRecordCell.swift */; };
 		870055C128EE966100F8BCA9 /* SettingRecordCellInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870055C028EE966100F8BCA9 /* SettingRecordCellInfo.swift */; };
 		870055C328EE974600F8BCA9 /* SettingRecordVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870055C228EE974600F8BCA9 /* SettingRecordVM.swift */; };
+		8701B0BF2A41AA0F00201CB2 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D1250028771AAD00018658 /* Language.swift */; };
 		87035DF2282201A500055378 /* TimerVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87035DF1282201A500055378 /* TimerVM.swift */; };
 		87035DF7282225C800055378 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87035DF6282225C800055378 /* Protocols.swift */; };
 		870474F628F148C700CC03A8 /* SettingColorVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870474F528F148C700CC03A8 /* SettingColorVC.swift */; };
@@ -1539,6 +1540,7 @@
 				870E117B2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift in Sources */,
 				87FD9FA82998D0BD00D9B0FF /* TimerStopwatchAttributes.swift in Sources */,
 				87D4DE122A0F83A500993C5C /* CalendarWidgetTaskData.swift in Sources */,
+				8701B0BF2A41AA0F00201CB2 /* Language.swift in Sources */,
 				87DA71732A124261006294DE /* MonthWidgetData+Snapshot.swift in Sources */,
 				878B30EC2992BB5A00BE7413 /* widgetLiveActivity.swift in Sources */,
 				8760FB0E2A1DBBB00068CEF5 /* Widget+Extentions.swift in Sources */,
@@ -2017,7 +2019,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2044,7 +2046,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer/Global/Extension/String+Extension.swift
+++ b/Project_Timer/Global/Extension/String+Extension.swift
@@ -16,12 +16,12 @@ extension String {
     }
     /// 디바이스 언어별로 번역기능을 위한 함수, Localizable 파일 내 String 값에 해당되는 언어값 반환
     func localized(bundle: Bundle = .main, tableName: String = "Localizable") -> String {
-        return NSLocalizedString(self, tableName: tableName, value: "\(self)", comment: "")
+        return NSLocalizedString(self, tableName: tableName, bundle: Bundle.localizedBundle, value: self, comment: "")
     }
     
     func localizedForNewFeatures(input: String) -> String {
-        let localilzedString = NSLocalizedString(self, tableName: "newFeatures" , value: "\(self)", comment: "")
-        let localizedInput = NSLocalizedString(input, tableName: "newFeatures" , value: "\(input)", comment: "")
+        let localilzedString = NSLocalizedString(self, tableName: "newFeatures" , bundle: Bundle.localizedBundle, value: self, comment: "")
+        let localizedInput = NSLocalizedString(input, tableName: "newFeatures" , bundle: Bundle.localizedBundle, value: "\(input)", comment: "")
         return localilzedString.replacingOccurrences(of: "*", with: localizedInput)
     }
     

--- a/Project_Timer/Global/Language.swift
+++ b/Project_Timer/Global/Language.swift
@@ -13,6 +13,52 @@ enum Language: String {
     case en
     
     static var currentLanguage: Language {
-        return Language(rawValue: Locale.current.languageCode ?? "en") ?? .en
+        if #available(iOS 16.0, *) {
+            guard let locale = Locale.preferredLanguages.first,
+                  let languageCode = Locale(identifier: locale).language.languageCode?.identifier else {
+                return .en
+            }
+            
+            return Language(rawValue: languageCode) ?? .en
+        } else {
+            guard let locale = Locale.preferredLanguages.first,
+                  let languageCode = Locale(identifier: locale).languageCode else {
+                return .en
+            }
+            
+            return Language(rawValue: languageCode) ?? .en
+        }
+        
+    }
+}
+
+extension Bundle {
+    static var koBundle: Bundle {
+        guard let koPath = Bundle.main.path(forResource: "ko", ofType: "lproj"),
+              let koBundle = Bundle(path: koPath) else {
+            print("Error: Bundle of \"ko\" can't access")
+            return Bundle.main
+        }
+        
+        return koBundle
+    }
+    
+    static var enBundle: Bundle {
+        guard let enPath = Bundle.main.path(forResource: "en", ofType: "lproj"),
+              let enBundle = Bundle(path: enPath) else {
+            print("Error: Bundle of \"en\" can't access")
+            return Bundle.main
+        }
+        
+        return enBundle
+    }
+    
+    static var localizedBundle: Bundle {
+        switch Language.currentLanguage {
+        case .ko:
+            return Bundle.koBundle
+        case .en:
+            return Bundle.enBundle
+        }
     }
 }

--- a/Project_Timer/Widget/Widget+Extentions.swift
+++ b/Project_Timer/Widget/Widget+Extentions.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension String {
     func localizedForWidget(bundle: Bundle = .main, tableName: String = "LocalizableForWidget") -> String {
-        return NSLocalizedString(self, tableName: tableName, value: "\(self)", comment: "")
+        return NSLocalizedString(self, tableName: tableName, bundle: Bundle.localizedBundle, value: self, comment: "")
     }
 }
 

--- a/Widget/Widgets/CalendarWidget/CalendarWidgetView.swift
+++ b/Widget/Widgets/CalendarWidget/CalendarWidgetView.swift
@@ -30,13 +30,7 @@ struct CalendarWidgetView: View {
     }
     
     var isKorean: Bool {
-        if #available(iOS 16.0, *){
-            let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
-            return languageCode == "ko"
-        } else {
-            let languageCode = Locale.current.languageCode ?? "en"
-            return languageCode == "ko"
-        }
+        return Language.currentLanguage == .ko
     }
 }
 


### PR DESCRIPTION
### 개요
- Issue: #86 

---

### 변경사항
- [x] NSLocalizedString 문제 해결
- [x] preferredLanguages.first를 통해 locale값을 접근하는 식으로 수정
- [x] extension Bundle 추가 (koBundle, enBundle)
---

### 레퍼런스
- [https://stackoverflow.com/questions/57178945/how-to-obtain-nslocalizedstring-for-specific-locale-or-how-to-get-non-localized](https://stackoverflow.com/questions/57178945/how-to-obtain-nslocalizedstring-for-specific-locale-or-how-to-get-non-localized)
- [https://hyesunzzang.tistory.com/80](https://hyesunzzang.tistory.com/80)
